### PR TITLE
Fix: remove blank line between debug-log print terminal groups #1

### DIFF
--- a/lib/formatGroupedChanges.js
+++ b/lib/formatGroupedChanges.js
@@ -1,16 +1,16 @@
 const formatGroupedChanges = (groupedChanges, locale, customTexts) => {
     let result = '';
     if (groupedChanges.added.length) {
-        result += `${customTexts.addedTitle || locale.addedTitle}\n` + groupedChanges.added.join('\n') + '\n\n';
+        result += `${customTexts.addedTitle || locale.addedTitle}\n` + groupedChanges.added.join('\n') + '\n';
     }
     if (groupedChanges.deleted.length) {
-        result += `${customTexts.deletedTitle || locale.deletedTitle}\n` + groupedChanges.deleted.join('\n') + '\n\n';
+        result += `${customTexts.deletedTitle || locale.deletedTitle}\n` + groupedChanges.deleted.join('\n') + '\n';
     }
     if (groupedChanges.edited.length) {
-        result += `${customTexts.editedTitle || locale.editedTitle}\n` + groupedChanges.edited.join('\n') + '\n\n';
+        result += `${customTexts.editedTitle || locale.editedTitle}\n` + groupedChanges.edited.join('\n') + '\n';
     }
     if (groupedChanges.arrayChange.length) {
-        result += `${customTexts.arrayChangeTitle || locale.arrayChangeTitle}\n` + groupedChanges.arrayChange.join('\n') + '\n\n';
+        result += `${customTexts.arrayChangeTitle || locale.arrayChangeTitle}\n` + groupedChanges.arrayChange.join('\n') + '\n';
     }
     
     return result.trim();


### PR DESCRIPTION
## Related issues

- #1 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
	- Enhanced the formatting of output strings for grouped changes, ensuring a cleaner presentation by removing extra newline characters.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->